### PR TITLE
Add editable URL to browser tab

### DIFF
--- a/frontend/src/components/Browser.tsx
+++ b/frontend/src/components/Browser.tsx
@@ -19,9 +19,11 @@ function Browser(): JSX.Element {
     setEditableUrl(e.target.value);
   };
 
-  const handleUrlBlur = () => {
-    dispatch(setUrl(editableUrl));
-  };
+  const handleURLBar = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      dispatch(setUrl(editableUrl));
+    }
+  }
 
   const imgSrc =
     screenshotSrc && screenshotSrc.startsWith("data:image/png;base64,")
@@ -35,7 +37,7 @@ function Browser(): JSX.Element {
           type="text"
           value={editableUrl}
           onChange={handleUrlChange}
-          onBlur={handleUrlBlur}
+          onKeyDown={handleURLBar}
           className="w-full bg-transparent border-none outline-none text-neutral-400"
         />
       </div>

--- a/frontend/src/components/Browser.tsx
+++ b/frontend/src/components/Browser.tsx
@@ -4,7 +4,7 @@ import { IoIosGlobe } from "react-icons/io";
 import { useSelector, useDispatch } from "react-redux";
 import { I18nKey } from "#/i18n/declaration";
 import { RootState } from "#/store";
-import { setUrl } from "#/state/browserSlice";
+import { sendUrl } from "#/state/browserSlice";
 
 function Browser(): JSX.Element {
   const { t } = useTranslation();
@@ -21,7 +21,7 @@ function Browser(): JSX.Element {
 
   const handleURLBar = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      dispatch(setUrl(editableUrl));
+      dispatch(sendUrl(editableUrl));
     }
   }
 

--- a/frontend/src/components/Browser.tsx
+++ b/frontend/src/components/Browser.tsx
@@ -1,16 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IoIosGlobe } from "react-icons/io";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { I18nKey } from "#/i18n/declaration";
 import { RootState } from "#/store";
+import { setUrl } from "#/state/browserSlice";
 
 function Browser(): JSX.Element {
   const { t } = useTranslation();
-
+  const dispatch = useDispatch();
   const { url, screenshotSrc } = useSelector(
     (state: RootState) => state.browser,
   );
+
+  const [editableUrl, setEditableUrl] = useState(url);
+
+  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditableUrl(e.target.value);
+  };
+
+  const handleUrlBlur = () => {
+    dispatch(setUrl(editableUrl));
+  };
 
   const imgSrc =
     screenshotSrc && screenshotSrc.startsWith("data:image/png;base64,")
@@ -20,7 +31,13 @@ function Browser(): JSX.Element {
   return (
     <div className="h-full w-full flex flex-col text-neutral-400">
       <div className="w-full p-2 truncate border-b border-neutral-600">
-        {url}
+        <input
+          type="text"
+          value={editableUrl}
+          onChange={handleUrlChange}
+          onBlur={handleUrlBlur}
+          className="w-full bg-transparent border-none outline-none text-neutral-400"
+        />
       </div>
       <div className="overflow-y-auto grow scrollbar-hide rounded-xl">
         {screenshotSrc ? (

--- a/frontend/src/services/browseService.ts
+++ b/frontend/src/services/browseService.ts
@@ -1,0 +1,8 @@
+import ActionType from "#/types/ActionType";
+import Session from "./session";
+
+export function updateBrowserTabUrl(newUrl: string): void {
+  const event = { action: ActionType.BROWSE, args: { url: newUrl } };
+  const eventString = JSON.stringify(event);
+  Session.send(eventString);
+}

--- a/frontend/src/state/browserSlice.ts
+++ b/frontend/src/state/browserSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { updateBrowserTabUrl } from "#/services/browseService";
 
 export const initialState = {
   // URL of browser window (placeholder for now, will be replaced with the actual URL later)
@@ -13,6 +14,7 @@ export const browserSlice = createSlice({
   reducers: {
     setUrl: (state, action) => {
       state.url = action.payload;
+      updateBrowserTabUrl(action.payload);
     },
     setScreenshotSrc: (state, action) => {
       state.screenshotSrc = action.payload;

--- a/frontend/src/state/browserSlice.ts
+++ b/frontend/src/state/browserSlice.ts
@@ -14,14 +14,17 @@ export const browserSlice = createSlice({
   reducers: {
     setUrl: (state, action) => {
       state.url = action.payload;
-      updateBrowserTabUrl(action.payload);
     },
     setScreenshotSrc: (state, action) => {
       state.screenshotSrc = action.payload;
     },
+    sendUrl: (state, action) => {
+      state.url = action.payload;
+      updateBrowserTabUrl(action.payload);
+    }
   },
 });
 
-export const { setUrl, setScreenshotSrc } = browserSlice.actions;
+export const { setUrl, setScreenshotSrc, sendUrl } = browserSlice.actions;
 
 export default browserSlice.reducer;

--- a/opendevin/server/session/session.py
+++ b/opendevin/server/session/session.py
@@ -17,6 +17,7 @@ from opendevin.events.observation import (
     CmdOutputObservation,
     NullObservation,
 )
+from opendevin.events.observation.browse import BrowserOutputObservation
 from opendevin.events.serialization import event_from_dict, event_to_dict
 from opendevin.events.stream import EventStreamSubscriber
 from opendevin.llm.llm import LLM
@@ -132,7 +133,7 @@ class Session:
         if event.source == EventSource.AGENT:
             await self.send(event_to_dict(event))
         elif event.source == EventSource.USER and isinstance(
-            event, CmdOutputObservation
+            event, (CmdOutputObservation, BrowserOutputObservation)
         ):
             await self.send(event_to_dict(event))
 


### PR DESCRIPTION
Add editable URL input field to Browser component

* Add an input field in `frontend/src/components/Browser.tsx` to allow editing the URL.
* Add `handleUrlChange` and `handleUrlBlur` handlers to update the URL state.
* Implement `updateBrowserTabUrl` function in `frontend/src/services/browseService.ts` to send data using websocket for updating the browser tab URL.
* Modify `frontend/src/state/browserSlice.ts` to include a new action to update the URL state and call `updateBrowserTabUrl` function.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenDevin/OpenDevin?shareId=b39056db-d2ea-402e-aabd-c77505aa2575).**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
