### PR TITLE
Update containers.py to fix error 429

### DIFF
--- a/openhands/runtime/impl/docker/containers.py
+++ b/openhands/runtime/impl/docker/containers.py
@@ -9,7 +9,8 @@ def stop_all_containers(prefix: str) -> None:
             try:
                 if container.name.startswith(prefix):
                     # TODO: use config to stop containers
-                    # container.stop()
+                    container.stop()
+                    container.remove()
                     pass
             except docker.errors.APIError:
                 pass


### PR DESCRIPTION
Original error was You have to remove (or rename) that container to be able to reuse that name .Container kevin-runtime-persisted-root-_mnt_projects already exists. Removing...

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change fixes a bug that could prevent the application from starting, particularly when using persistent runtimes. Users might have seen errors related to "container name already in use" or "Conflict." With this fix, the application will now correctly clean up old instances, ensuring a smoother and more reliable startup process.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR addresses an issue where new Docker containers could not be created due to name conflicts with pre-existing containers.
The root cause was traced to the stop_all_containers function in openhands/runtime/impl/docker/containers.py. In this function, the lines responsible for stopping and removing Docker containers were either commented out or missing.
The fix involves:
Uncommenting the container.stop() line.
Adding a container.remove() call immediately after container.stop().

---
**Link of any specific issues this addresses:**
